### PR TITLE
Use the best bitrate video for twitter embeds

### DIFF
--- a/twitfix.py
+++ b/twitfix.py
@@ -277,6 +277,7 @@ def link_to_vnf_from_api(video_link):
             for video in tweet['extended_entities']['media'][0]['video_info']['variants']:
                 if video['content_type'] == "video/mp4" and video['bitrate'] > best_bitrate:
                     url = video['url']
+                    best_bitrate = video['bitrate']
     elif tweetType(tweet) == "Text":
         url   = ""
         thumb = ""


### PR DESCRIPTION
In the previous repo there was a PR that changed how the bitrate sorting works (robinuniverse/TwitFix#48), although it wasn't implemented correctly which made it pick the worst quality bitrate video twitter had. This is a simple fix to that.

No testing done as I don't have a dev env, but I don't see it causing any issues