### PR TITLE
Add support for URL previews for matrix Synapse homeservers

### DIFF
--- a/twitfix.py
+++ b/twitfix.py
@@ -31,6 +31,7 @@ generate_embed_user_agents = [
     "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)", 
     "TelegramBot (like TwitterBot)", 
     "Mozilla/5.0 (compatible; January/1.0; +https://gitlab.insrt.uk/revolt/january)", 
+    "Synapse (bot; +https://github.com/matrix-org/synapse)",
     "test"]
 
 @app.route('/') # If the useragent is discord, return the embed, if not, redirect to configured repo directly


### PR DESCRIPTION
Adds support for Synapse homeservers for Matrix.

Matrix generates URL previews for clients by the server making a single request to the URL and then caching and serving that result. Because of this, BetterTwitFix doesn't function as expected as Synapse uses an unrecognized user-agent string `Synapse (bot; +https://github.com/matrix-org/synapse)`. Further details are available at https://matrix-org.github.io/synapse/latest/setup/installation.html?highlight=url%20pre#url-previews, and the value for the user-agent string was pulled from https://github.com/matrix-org/synapse/blob/master/synapse/rest/media/v1/preview_url_resource.py

I tested this locally with Postman and on my own homeserver and verified that it works.