### PR TITLE
add /all as an alternate method of creating a composite image of all images in a tweet

### DIFF
--- a/twitfix.py
+++ b/twitfix.py
@@ -78,7 +78,7 @@ def twitfix(sub_path):
         else:
             print(" ➤ [ R ] Redirect to MP4 using d.fxtwitter.com")
             return dir(sub_path)
-    elif request.url.startswith("https://c.vx"):
+    elif request.url.startswith("https://c.vx") or request.url.endswith('/all'):
         twitter_url = sub_path
 
         if match.start() == 0:


### PR DESCRIPTION
Another one line change, feel free to reject this if you don't like the idea. I just don't know of a better way to get in contact to ask if you agreed with this change or not.

Adds /all as a route similar to `/1`, `/2`, `/3`, `/4` at the end of the url in addition to using `c.vxtwitter.com`. Adding it as part of the URL seemed more consistent and user friendly to me. I would argue that combining all images into one should be default behavior as that is most similar to what twitter does by default (when it works, anyway). But of course, this is your project so feel free to design it as you prefer.