### PR TITLE
Update fxtwitter to TwitFix in README to prevent confusion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 (A fork of TwitFix)
 Basic flask server that serves fixed twitter video embeds to desktop discord by using either the Twitter API or Youtube-DL to grab tweet video information. This also automatically embeds the first link in the text of non video tweets (API Only)
 
-## Differences from fxtwitter
-fxtwitter exposed all recently processed tweets publicly via a "latest" and "top" page.
+## Differences from TwitFix
+TwitFix exposed all recently processed tweets publicly via a "latest" and "top" page.
 
 Even though Tweets are public, it was a personal concern for me that a tweet with potentially sensitive information in it could suddenly be shown to however many people were browsing the latest tweets page, and could be used as a tool for harassment. This was removed in [The following commit](https://github.com/dylanpdx/BetterTwitFix/commit/87ba86ba502e73ddb370bd4e5b964548d3272400#diff-a11c36d9b2d53672d6b3d781dca5bef9129159947de66bc3ffaec5fab389d80cL115)
 


### PR DESCRIPTION
Since fxtwitter.com doesn't run TwitFix anymore (and hasn't for well over a year) and [does not have the tweet indexing privacy issues you mentioned](https://github.com/FixTweet/FixTweet#built-with-privacy-in-mind), I would strongly suggest changing "fxtwitter" to "TwitFix" to prevent user confusion with the current service. 👍