### PR TITLE
Fix getTweetData when the default config is used

### DIFF
--- a/twitfix.py
+++ b/twitfix.py
@@ -177,7 +177,12 @@ def getTweetData(twitter_url,include_txt="false",include_rtf="false"):
         rawTweetData = None
     if rawTweetData is None:
         try:
-            rawTweetData = twExtract.extractStatus(twitter_url,workaroundTokens=config['config']['workaroundTokens'].split(','))
+            if config['config']['workaroundTokens'] is not None:
+                workaroundTokens = config['config']['workaroundTokens'].split(",")
+            else:
+                workaroundTokens = None
+            
+            rawTweetData = twExtract.extractStatus(twitter_url,workaroundTokens=workaroundTokens)
         except:
             rawTweetData = None
     if rawTweetData == None or 'error' in rawTweetData:

--- a/twitfix.py
+++ b/twitfix.py
@@ -172,7 +172,7 @@ def getTweetData(twitter_url,include_txt="false",include_rtf="false"):
         return cachedVNF
 
     try:
-        rawTweetData = twExtract.extractStatusV2Anon(twitter_url)
+        rawTweetData = twExtract.extractStatusV2Anon(twitter_url, None)
     except:
         rawTweetData = None
     if rawTweetData is None:


### PR DESCRIPTION
Maybe I did something wrong, but the default config has `workaroundTokens` set to null (also I don't think the hosting guide mentions to set them to anything?):
https://github.com/dylanpdx/BetterTwitFix/blob/22433cdab5e5b3559eec18815c9571272719dda5/config.json#L13

However, the code that used the `workaroundTokens` value didn't check if it was an string before trying to split it, so this PR fixes this.

Also, I've also added the second missing parameter to `extractStatusV2Anon` (also in `getTweetData`, all the tests also use None and the function actually doesn't even use it?)