### PR TITLE
fix DB cache

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -49,7 +49,9 @@ def addVnfToTweetIdCache(tweet_id, vnf):
     global link_cache
     try:
         if link_cache_system == "db":
-                out = db.linkCache.update_one(vnf)
+                filter_query = {'tweet': tweet_id}
+                update_operation = {'$set': vnf}
+                out = db.linkCache.update_one(filter_query, update_operation, upsert=True)
                 log.debug("Link added to DB cache ")
                 return True
         elif link_cache_system == "json":
@@ -86,7 +88,7 @@ def getVnfFromTweetIdCache(tweet_id):
         collection = db.linkCache
         vnf        = collection.find_one({'tweet': tweet_id})
         if vnf != None: 
-            hits   = ( vnf['hits'] + 1 ) 
+            hits   = ( vnf.get('hits', 0) + 1 ) 
             log.debug("Link located in DB cache.")
             query  = { 'tweet': tweet_id }
             change = { "$set" : { "hits" : hits } }


### PR DESCRIPTION
Closes #275 

I have tested this on my self-hosted instance. 

- Fixes adding to cache
- Fixes retrival because the code failed to take into account that the first time the hits ket/var/columnn whatever it is inside this DB does *not* exists so the first time it's going to default to 0 followed by + 1 so the logic is now solid and code correct

I can confirm the following:
No errors or stack trace caused by the DB actually being used
I used RAM cache before, which comes with a warning and never tried JSON cache. I assume the official vxtwitter site is then using either RAM or JSON? Because it does seem a cache is used by y'all since the embeds are fast when reposting same link which is *now* what I experience post fix when using DB cache

```
Apr 22 20:00:36 vps-671320a7 uwsgi[31937]: spawned uWSGI worker 2 (pid: 31940, cores: 1)
Apr 22 20:00:36 vps-671320a7 uwsgi[31937]: spawned uWSGI worker 3 (pid: 31941, cores: 1)
Apr 22 20:00:36 vps-671320a7 uwsgi[31937]: spawned uWSGI worker 4 (pid: 31942, cores: 1)
Apr 22 20:00:36 vps-671320a7 uwsgi[31937]: spawned uWSGI worker 5 (pid: 31943, cores: 1)
Apr 22 20:00:50 vps-671320a7 uwsgi[31939]:  > [ ✔ ] Tweet Data Get success
Apr 22 20:00:50 vps-671320a7 uwsgi[31939]: [pid: 31939|app: 0|req: 1/1] 162.158.116.141 () {76 vars in 1828 bytes} [Tue Apr 22 20:00:50 2025] GET /game_2077/status/1914711965605245039 => generated 1840 bytes in 52 msecs (HTTP/1.1 200) 3 headers in 113 bytes (2 switches on core 0)
Apr 22 20:00:55 vps-671320a7 uwsgi[31940]:  > [ ✔ ] Tweet Data Get success
Apr 22 20:00:55 vps-671320a7 uwsgi[31940]: [pid: 31940|app: 0|req: 1/2] 162.158.116.141 () {76 vars in 1830 bytes} [Tue Apr 22 20:00:55 2025] GET /DrClownPhD/status/1914507197393821847 => generated 2830 bytes in 52 msecs (HTTP/1.1 200) 3 headers in 113 bytes (1 switches on core 0)
Apr 22 20:01:01 vps-671320a7 uwsgi[31943]:  > [ ✔ ] Tweet Data Get success
Apr 22 20:01:01 vps-671320a7 uwsgi[31943]: [pid: 31943|app: 0|req: 1/3] 162.158.116.141 () {78 vars in 1859 bytes} [Tue Apr 22 20:01:01 2025] GET /game_2077/status/1914711965605245039 => generated 1840 bytes in 97 msecs (HTTP/1.1 200) 3 headers in 113 bytes (1 switches on core 0)
```